### PR TITLE
Fix some compile errors

### DIFF
--- a/contrib/epee/include/storages/portable_storage.h
+++ b/contrib/epee/include/storages/portable_storage.h
@@ -427,7 +427,7 @@ namespace epee
       TRY_ENTRY();
       CHECK_AND_ASSERT(hsec_array, false);
       if(hsec_array->type() != typeid(array_entry_t<section>))
-        return nullptr;
+        return false;
       array_entry_t<section>& sec_array = boost::get<array_entry_t<section>>(*hsec_array);
       h_child_section = sec_array.get_next_val();
       if(!h_child_section)

--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -502,9 +502,6 @@ static void (*const extra_hashes[4])(const void *, size_t, char *) = {
 #define INIT_SIZE_BLK   8
 #define INIT_SIZE_BYTE (INIT_SIZE_BLK * AES_BLOCK_SIZE)
 
-extern int aesb_single_round(const uint8_t *in, uint8_t*out, const uint8_t *expandedKey);
-extern int aesb_pseudo_round(const uint8_t *in, uint8_t *out, const uint8_t *expandedKey);
-
 static size_t e2i(const uint8_t* a, size_t count) { return (*((uint64_t*)a) / AES_BLOCK_SIZE) & (count - 1); }
 
 static void mul(const uint8_t* a, const uint8_t* b, uint8_t* res) {

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1045,6 +1045,10 @@ namespace nodetool
       std::string port_=port;
       peerid_type pr_ = pr;
       auto cb_ = cb;*/
+
+      // GCC 5.1.0 gives error with second use of uint64_t (peerid_type) variable.
+      peerid_type pr_ = pr;
+
       bool inv_call_res = epee::net_utils::async_invoke_remote_command2<COMMAND_PING::response>(ping_context.m_connection_id, COMMAND_PING::ID, req, m_net_server.get_config_object(),
         [=](int code, const COMMAND_PING::response& rsp, p2p_connection_context& context)
       {
@@ -1056,7 +1060,7 @@ namespace nodetool
 
         if(rsp.status != PING_OK_RESPONSE_STATUS_TEXT || pr != rsp.peer_id)
         {
-          LOG_PRINT_CC_L2(ping_context, "back ping invoke wrong response \"" << rsp.status << "\" from" << ip << ":" << port << ", hsh_peer_id=" << pr << ", rsp.peer_id=" << rsp.peer_id);
+          LOG_PRINT_CC_L2(ping_context, "back ping invoke wrong response \"" << rsp.status << "\" from" << ip << ":" << port << ", hsh_peer_id=" << pr_ << ", rsp.peer_id=" << rsp.peer_id);
           return;
         }
         m_net_server.get_config_object().close(ping_context.m_connection_id);


### PR DESCRIPTION
Remove obsolete declarations from portable slow-hash
Fix compile for GCC 5.1.0 (from Monero)
