### PR TITLE
Fix unconfirmed balance, accurately report fees

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -930,7 +930,7 @@ bool simple_wallet::transfer(const std::vector<std::string> &args_)
     
     uint64_t dust_in_fee = total_fee - ptx_vector.size()*DEFAULT_FEE;
     
-    //AC: Always confirm
+    //Always confirm
     std::string prompt_str = "Your transaction needs to be split into " + std::to_string(ptx_vector.size()) + " transactions.\n" 
                              + "This will result in a fee of "  + print_money(total_fee);
     if (dust_in_fee != 0) prompt_str += " of which " + print_money(dust_in_fee) + " is dust from change";

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -813,7 +813,7 @@ void wallet2::commit_tx(pending_tx& ptx)
     it->m_spent = true;
 
   LOG_PRINT_L0("Transaction successfully sent. <" << get_transaction_hash(ptx.tx) << ">" << ENDL
-            << "Commission: " << print_money(ptx.fee+ptx.dust) << " (dust: " << print_money(ptx.dust) << ")" << ENDL
+            << "Commission: " << print_money(ptx.fee) << " (dust: " << print_money(ptx.dust) << ")" << ENDL  //AC: ptx.fee includes fee-dust.  dust now lists dust sent elsewhere.  Not fee or change dust. 
             << "Balance: " << print_money(balance()) << ENDL
             << "Unlocked: " << print_money(unlocked_balance()) << ENDL
             << "Please, wait for confirmation for your balance to be unlocked.");

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -813,7 +813,7 @@ void wallet2::commit_tx(pending_tx& ptx)
     it->m_spent = true;
 
   LOG_PRINT_L0("Transaction successfully sent. <" << get_transaction_hash(ptx.tx) << ">" << ENDL
-            << "Commission: " << print_money(ptx.fee) << " (dust: " << print_money(ptx.dust) << ")" << ENDL  //AC: ptx.fee includes fee-dust.  dust now lists dust sent elsewhere.  Not fee or change dust. 
+            << "Commission: " << print_money(ptx.fee) << " (dust: " << print_money(ptx.dust) << ")" << ENDL 
             << "Balance: " << print_money(balance()) << ENDL
             << "Unlocked: " << print_money(unlocked_balance()) << ENDL
             << "Please, wait for confirmation for your balance to be unlocked.");

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -472,10 +472,17 @@ namespace tools
       return true;
     });
     THROW_WALLET_EXCEPTION_IF(!all_are_txin_to_key, error::unexpected_txin_type, tx);
+    
+    //AC
+    
+    bool dust_sent_elsewhere = (dust_policy.addr_for_dust.m_spend_public_key != change_dts.addr.m_spend_public_key 
+                                || dust_policy.addr_for_dust.m_view_public_key  != change_dts.addr.m_view_public_key);
+    
+    if (dust_policy.add_to_fee || dust_sent_elsewhere  )  change_dts.amount -= dust;            //AC
 
     ptx.key_images = key_images;
-    ptx.fee = fee;
-    ptx.dust = dust;
+    ptx.fee = (dust_policy.add_to_fee ? fee + dust : fee);                    //AC
+    ptx.dust = ((!dust_policy.add_to_fee && dust_sent_elsewhere) ? dust : 0); //AC: Only record dust amount if it wasn't included in the fee or the change.
     ptx.tx = tx;
     ptx.change_dts = change_dts;
     ptx.selected_transfers = selected_transfers;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -473,16 +473,14 @@ namespace tools
     });
     THROW_WALLET_EXCEPTION_IF(!all_are_txin_to_key, error::unexpected_txin_type, tx);
     
-    //AC
-    
     bool dust_sent_elsewhere = (dust_policy.addr_for_dust.m_spend_public_key != change_dts.addr.m_spend_public_key 
                                 || dust_policy.addr_for_dust.m_view_public_key  != change_dts.addr.m_view_public_key);
     
-    if (dust_policy.add_to_fee || dust_sent_elsewhere  )  change_dts.amount -= dust;            //AC
+    if (dust_policy.add_to_fee || dust_sent_elsewhere  )  change_dts.amount -= dust;     
 
     ptx.key_images = key_images;
-    ptx.fee = (dust_policy.add_to_fee ? fee + dust : fee);                    //AC
-    ptx.dust = ((!dust_policy.add_to_fee && dust_sent_elsewhere) ? dust : 0); //AC: Only record dust amount if it wasn't included in the fee or the change.
+    ptx.fee = (dust_policy.add_to_fee ? fee + dust : fee);                    
+    ptx.dust = ((!dust_policy.add_to_fee && dust_sent_elsewhere) ? dust : 0);
     ptx.tx = tx;
     ptx.change_dts = change_dts;
     ptx.selected_transfers = selected_transfers;


### PR DESCRIPTION
Problem: 

Wallet may report incorrect balance before all transactions are confirmed.  This is because dust amounts from change are added to fee by default, but not subtracted from the change amount when counting the wallet balance. The reported fee in the confirmation message of simplewallet also does   not take this into account.

For example, try sending 1.123456 from one wallet to another.  

Suggested fix:

In wallet2::transfer, after transaction details and dust amount from change has been determined,
record dust, fee and change amount according to the dust policy:

   -ptx.fee += dust if dust is added to fee
   -ptx.dust = dust only if dust is not added to fee and not kept in change according to dust policy;
   otherwise ptx.dust = 0.
   -change_dts.amount -= dust if dust is added to fee or sent elsewhere according to dust policy
   -modify wallet confirmation message to accurately report fees and account for different dust policies

I removed the if statement around the confirm message in simplewallet since I prefer alway-confirm behaviour, but that is just my preference.
