### PR TITLE
Subtract fee from amount

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -1007,7 +1007,7 @@ bool simple_wallet::transfer(const std::vector<std::string> &args_)
   }
   catch (const tools::error::subtract_fee_error&)
   {
-    fail_msg_writer() << "fee amount exceeds specified first destination amount";
+    fail_msg_writer() << "first destination amount does not exceed fee amount";
   }
   catch (const tools::error::tx_too_big& e)
   {

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -875,16 +875,16 @@ bool simple_wallet::transfer(const std::vector<std::string> &args_)
   tools::tx_fee_policy fee_policy;
   if (local_args.back().compare("subtract-fee")==0)
   {
-    fee_policy = tools::SUBTRACT_FROM_FIRST;
+    fee_policy = tools::tx_fee_policy::SUBTRACT_FROM_FIRST;
     local_args.pop_back();
   }
   else if (local_args.back().compare("subtract-fee-from-all")==0)
   {
-    fee_policy = tools::SUBTRACT_FROM_ALL;
+    fee_policy = tools::tx_fee_policy::SUBTRACT_FROM_ALL;
     local_args.pop_back();
   }
   else
-    fee_policy = tools::ADD_TO_TOTAL;
+    fee_policy = tools::tx_fee_policy::ADD_TO_TOTAL;
 
   std::vector<uint8_t> extra;
   if (1 == local_args.size() % 2)

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -230,7 +230,7 @@ simple_wallet::simple_wallet()
   m_cmd_binder.set_handler("incoming_transfers", boost::bind(&simple_wallet::show_incoming_transfers, this, _1), "incoming_transfers [available|unavailable] - Show incoming transfers - all of them or filter them by availability");
   m_cmd_binder.set_handler("payments", boost::bind(&simple_wallet::show_payments, this, _1), "payments <payment_id_1> [<payment_id_2> ... <payment_id_N>] - Show payments <payment_id_1>, ... <payment_id_N>");
   m_cmd_binder.set_handler("bc_height", boost::bind(&simple_wallet::show_blockchain_height, this, _1), "Show blockchain height");
-  m_cmd_binder.set_handler("transfer", boost::bind(&simple_wallet::transfer, this, _1), "transfer <mixin_count> <addr_1> <amount_1> [<addr_2> <amount_2> ... <addr_N> <amount_N>] [payment_id] [subtract-fee|subtract-fee-from-all]\n                     - Transfer <amount_1>,... <amount_N> to <address_1>,... <address_N>, respectively,\n                       optionally subtracting the transaction fee from <amount_1> (subtract-fee) or from all amounts equally (subtract-fee-from-all).\n                       <mixin_count> is the number of transactions yours is indistinguishable from (from 0 to maximum available).");
+  m_cmd_binder.set_handler("transfer", boost::bind(&simple_wallet::transfer, this, _1), "transfer <mixin_count> <addr_1> <amount_1> [<addr_2> <amount_2> ... <addr_N> <amount_N>] [payment_id] [subtract-fee]\n                     - Transfer <amount_1>,... <amount_N> to <address_1>,... <address_N>, respectively,\n                       optionally subtracting the transaction fee from <amount_1> (subtract-fee).\n                       <mixin_count> is the number of transactions yours is indistinguishable from (from 0 to maximum available).");
   m_cmd_binder.set_handler("set_log", boost::bind(&simple_wallet::set_log, this, _1), "set_log <level> - Change current log detalization level, <level> is a number 0-4");
   m_cmd_binder.set_handler("address", boost::bind(&simple_wallet::print_address, this, _1), "Show current wallet public address");
   m_cmd_binder.set_handler("save", boost::bind(&simple_wallet::save, this, _1), "Save wallet synchronized data");
@@ -864,6 +864,13 @@ bool simple_wallet::transfer(const std::vector<std::string> &args_)
     return true;
   }
 
+  bool subtract_fee = false;
+  if (local_args.back().compare("subtract-fee")==0)
+  {
+    subtract_fee = true;
+    local_args.pop_back();
+  }
+
   size_t fake_outs_count;
   if(!epee::string_tools::get_xtype_from_string(fake_outs_count, local_args[0]))
   {
@@ -871,20 +878,6 @@ bool simple_wallet::transfer(const std::vector<std::string> &args_)
     return true;
   }
   local_args.erase(local_args.begin());
-
-  tools::tx_fee_policy fee_policy;
-  if (local_args.back().compare("subtract-fee")==0)
-  {
-    fee_policy = tools::tx_fee_policy::SUBTRACT_FROM_FIRST;
-    local_args.pop_back();
-  }
-  else if (local_args.back().compare("subtract-fee-from-all")==0)
-  {
-    fee_policy = tools::tx_fee_policy::SUBTRACT_FROM_ALL;
-    local_args.pop_back();
-  }
-  else
-    fee_policy = tools::tx_fee_policy::ADD_TO_TOTAL;
 
   std::vector<uint8_t> extra;
   if (1 == local_args.size() % 2)
@@ -932,7 +925,7 @@ bool simple_wallet::transfer(const std::vector<std::string> &args_)
   try
   {
     // figure out what tx will be necessary
-    auto ptx_vector = m_wallet->create_transactions(dsts, fake_outs_count, 0 /* unlock_time */, DEFAULT_FEE, extra, fee_policy);
+    auto ptx_vector = m_wallet->create_transactions(dsts, fake_outs_count, 0 /* unlock_time */, DEFAULT_FEE, extra, subtract_fee);
 
     // if more than one tx necessary, prompt user to confirm
     if (ptx_vector.size() > 1)
@@ -1014,7 +1007,7 @@ bool simple_wallet::transfer(const std::vector<std::string> &args_)
   }
   catch (const tools::error::subtract_fee_error&)
   {
-    fail_msg_writer() << "at least one fee amount exceeds a destination amount";
+    fail_msg_writer() << "fee amount exceeds specified first destination amount";
   }
   catch (const tools::error::tx_too_big& e)
   {

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -838,6 +838,8 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions(std::vector<crypto
   // failsafe split attempt counter
   size_t attempt_count = 0;
 
+  THROW_WALLET_EXCEPTION_IF(fee_policy > tx_fee_policy::MAX_VALUE,error::invalid_fee_policy);
+
   for(attempt_count = 1; ;attempt_count++)
   {
     auto split_values = split_amounts(dsts, attempt_count);
@@ -854,12 +856,12 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions(std::vector<crypto
       // for each new destination vector (i.e. for each new tx)
       for (auto & dst_vector : split_values)
       {
-        if (fee_policy == SUBTRACT_FROM_FIRST)
+        if (fee_policy == tx_fee_policy::SUBTRACT_FROM_FIRST)
         {
           THROW_WALLET_EXCEPTION_IF(dst_vector[0].amount <= fee,error::subtract_fee_error);
           dst_vector[0].amount -= fee;
         }
-        else if (fee_policy == SUBTRACT_FROM_ALL)
+        else if (fee_policy == tx_fee_policy::SUBTRACT_FROM_ALL)
         {
           for (size_t n=0; n < dst_vector.size(); ++n)
           {
@@ -876,7 +878,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions(std::vector<crypto
         //If fee is added to total, also add dust change to total (specified by dust policy)
         //If fee is subtracted from one or all of the sent amounts then do not add dust change to the fee.  Send it back as change.
         //Alternatively, always calling with tx_dust_policy(fee,false,m_account_public_address) would maybe be less confusing for users.
-        if (fee_policy == ADD_TO_TOTAL)
+        if (fee_policy == tx_fee_policy::ADD_TO_TOTAL)
           transfer(dst_vector, fake_outs_count, unlock_time, fee, extra, detail::digit_split_strategy, tx_dust_policy(fee,true), tx, ptx);
         else
           transfer(dst_vector, fake_outs_count, unlock_time, fee, extra, detail::digit_split_strategy, tx_dust_policy(fee,false,m_account_public_address), tx, ptx);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -832,7 +832,7 @@ void wallet2::commit_tx(std::vector<pending_tx>& ptx_vector)
 //
 // this function will make multiple calls to wallet2::transfer if multiple
 // transactions will be required
-std::vector<wallet2::pending_tx> wallet2::create_transactions(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, const uint64_t fee, const std::vector<uint8_t> extra)
+std::vector<wallet2::pending_tx> wallet2::create_transactions(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, const uint64_t fee, const std::vector<uint8_t> extra, const tx_fee_policy fee_policy)
 {
 
   // failsafe split attempt counter
@@ -854,9 +854,33 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions(std::vector<crypto
       // for each new destination vector (i.e. for each new tx)
       for (auto & dst_vector : split_values)
       {
+        if (fee_policy == SUBTRACT_FROM_FIRST)
+        {
+          THROW_WALLET_EXCEPTION_IF(dst_vector[0].amount <= fee,error::subtract_fee_error);
+          dst_vector[0].amount -= fee;
+        }
+        else if (fee_policy == SUBTRACT_FROM_ALL)
+        {
+          for (size_t n=0; n < dst_vector.size(); ++n)
+          {
+            uint64_t old_amount = dst_vector[n].amount;
+            dst_vector[n].amount -= fee / dst_vector.size();
+            if (n + 1 == dst_vector.size())
+              dst_vector[n].amount -= fee % dst_vector.size();
+            THROW_WALLET_EXCEPTION_IF(old_amount == 0 || old_amount < dst_vector[n].amount,error::subtract_fee_error);
+          }
+        }
         cryptonote::transaction tx;
         pending_tx ptx;
-        transfer(dst_vector, fake_outs_count, unlock_time, fee, extra, tx, ptx);
+
+        //If fee is added to total, also add dust change to total (specified by dust policy)
+        //If fee is subtracted from one or all of the sent amounts then do not add dust change to the fee.  Send it back as change.
+        //Alternatively, always calling with tx_dust_policy(fee,false,m_account_public_address) would maybe be less confusing for users.
+        if (fee_policy == ADD_TO_TOTAL)
+          transfer(dst_vector, fake_outs_count, unlock_time, fee, extra, detail::digit_split_strategy, tx_dust_policy(fee,true), tx, ptx);
+        else
+          transfer(dst_vector, fake_outs_count, unlock_time, fee, extra, detail::digit_split_strategy, tx_dust_policy(fee,false,m_account_public_address), tx, ptx);
+
         ptx_vector.push_back(ptx);
 
         // mark transfers to be used as "spent"

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -834,8 +834,8 @@ void wallet2::commit_tx(std::vector<pending_tx>& ptx_vector)
 // transactions will be required
 std::vector<wallet2::pending_tx> wallet2::create_transactions(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, const uint64_t fee, const std::vector<uint8_t> extra, const bool subtract_fee)
 {
-  // Throw exception for zero destinations here since we may be manipulating amounts
-  // of members of dsts in this function if we are subtracting the fee
+  // Throw exception for zero destinations here since we may be manipulating
+  // members of dsts in this function if we are subtracting the fee from them
   THROW_WALLET_EXCEPTION_IF(dsts.empty(), error::zero_destination);
 
   // failsafe split attempt counter
@@ -866,9 +866,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions(std::vector<crypto
         cryptonote::transaction tx;
         pending_tx ptx;
 
-        //If fee is added to total, also add dust change to total (specified by dust policy),
-        //otherwise send dust change back to user.  Alternatively, always calling with tx_dust_policy(fee,false,m_account_public_address)
-        //would maybe be less confusing for users.
+        //If fee is subtracted from total, send dust change back to user, otherwise keep behaviour as before (dust is added to fee).
         if (subtract_fee)
           transfer(dst_vector, fake_outs_count, unlock_time, fee, extra, detail::digit_split_strategy, tx_dust_policy(fee,false,m_account_public_address), tx, ptx);
         else

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -77,14 +77,6 @@ namespace tools
     }
   };
 
-  enum tx_fee_policy : uint8_t
-  {
-    ADD_TO_TOTAL            = 0,
-    SUBTRACT_FROM_FIRST     = 1,
-    SUBTRACT_FROM_ALL       = 2,
-    MAX_VALUE               = SUBTRACT_FROM_ALL
-  };
-
   class wallet2
   {
     wallet2(const wallet2&) : m_run(true), m_callback(0) {};
@@ -175,7 +167,7 @@ namespace tools
     void transfer(const std::vector<cryptonote::tx_destination_entry>& dsts, size_t fake_outputs_count, uint64_t unlock_time, uint64_t fee, const std::vector<uint8_t>& extra, cryptonote::transaction& tx, pending_tx& ptx);
     void commit_tx(pending_tx& ptx_vector);
     void commit_tx(std::vector<pending_tx>& ptx_vector);
-    std::vector<pending_tx> create_transactions(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, const uint64_t fee, const std::vector<uint8_t> extra, const tx_fee_policy fee_policy);
+    std::vector<pending_tx> create_transactions(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, const uint64_t fee, const std::vector<uint8_t> extra, const bool subtract_fee);
     bool check_connection();
     void get_transfers(wallet2::transfer_container& incoming_transfers) const;
     void get_payments(const crypto::hash& payment_id, std::list<wallet2::payment_details>& payments, uint64_t min_height = 0) const;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -81,7 +81,8 @@ namespace tools
   {
     ADD_TO_TOTAL            = 0,
     SUBTRACT_FROM_FIRST     = 1,
-    SUBTRACT_FROM_ALL       = 2
+    SUBTRACT_FROM_ALL       = 2,
+    MAX_VALUE               = SUBTRACT_FROM_ALL
   };
 
   class wallet2

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -77,6 +77,13 @@ namespace tools
     }
   };
 
+  enum tx_fee_policy : uint8_t
+  {
+    ADD_TO_TOTAL            = 0,
+    SUBTRACT_FROM_FIRST     = 1,
+    SUBTRACT_FROM_ALL       = 2
+  };
+
   class wallet2
   {
     wallet2(const wallet2&) : m_run(true), m_callback(0) {};
@@ -167,7 +174,7 @@ namespace tools
     void transfer(const std::vector<cryptonote::tx_destination_entry>& dsts, size_t fake_outputs_count, uint64_t unlock_time, uint64_t fee, const std::vector<uint8_t>& extra, cryptonote::transaction& tx, pending_tx& ptx);
     void commit_tx(pending_tx& ptx_vector);
     void commit_tx(std::vector<pending_tx>& ptx_vector);
-    std::vector<pending_tx> create_transactions(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, const uint64_t fee, const std::vector<uint8_t> extra);
+    std::vector<pending_tx> create_transactions(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, const uint64_t fee, const std::vector<uint8_t> extra, const tx_fee_policy fee_policy);
     bool check_connection();
     void get_transfers(wallet2::transfer_container& incoming_transfers) const;
     void get_payments(const crypto::hash& payment_id, std::list<wallet2::payment_details>& payments, uint64_t min_height = 0) const;

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -521,6 +521,14 @@ namespace tools
       }
     };
     //----------------------------------------------------------------------------------------------------
+    struct subtract_fee_error : public transfer_error
+    {
+      explicit subtract_fee_error(std::string&& loc)
+        : transfer_error(std::move(loc), "fee amount exceeds destination amount")
+      {
+      }
+    };
+    //----------------------------------------------------------------------------------------------------
     struct wallet_rpc_error : public wallet_logic_error
     {
       const std::string& request() const { return m_request; }

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -521,6 +521,14 @@ namespace tools
       }
     };
     //----------------------------------------------------------------------------------------------------
+    struct invalid_fee_policy : public transfer_error
+    {
+      explicit invalid_fee_policy(std::string&& loc)
+        : transfer_error(std::move(loc), "fee policy not specified correctly")
+      {
+      }
+    };
+    //----------------------------------------------------------------------------------------------------
     struct subtract_fee_error : public transfer_error
     {
       explicit subtract_fee_error(std::string&& loc)

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -524,7 +524,7 @@ namespace tools
     struct subtract_fee_error : public transfer_error
     {
       explicit subtract_fee_error(std::string&& loc)
-        : transfer_error(std::move(loc), "fee amount exceeds destination amount")
+        : transfer_error(std::move(loc), "destination amount does not exceed fee amount")
       {
       }
     };

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -521,14 +521,6 @@ namespace tools
       }
     };
     //----------------------------------------------------------------------------------------------------
-    struct invalid_fee_policy : public transfer_error
-    {
-      explicit invalid_fee_policy(std::string&& loc)
-        : transfer_error(std::move(loc), "fee policy not specified correctly")
-      {
-      }
-    };
-    //----------------------------------------------------------------------------------------------------
     struct subtract_fee_error : public transfer_error
     {
       explicit subtract_fee_error(std::string&& loc)

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -171,7 +171,7 @@ namespace tools
 
     try
     {
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet.create_transactions(dsts, req.mixin, req.unlock_time, req.fee, extra, (tx_fee_policy)req.fee_policy);
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet.create_transactions(dsts, req.mixin, req.unlock_time, req.fee, extra, static_cast<tx_fee_policy>(req.fee_policy));
 
       // reject proposed transactions if there are more than one.  see on_transfer_split below.
       if (ptx_vector.size() != 1)
@@ -222,7 +222,7 @@ namespace tools
 
     try
     {
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet.create_transactions(dsts, req.mixin, req.unlock_time, req.fee, extra, (tx_fee_policy)req.fee_policy);
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet.create_transactions(dsts, req.mixin, req.unlock_time, req.fee, extra, static_cast<tx_fee_policy>(req.fee_policy));
 
       m_wallet.commit_tx(ptx_vector);
 

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -171,7 +171,7 @@ namespace tools
 
     try
     {
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet.create_transactions(dsts, req.mixin, req.unlock_time, req.fee, extra, static_cast<tx_fee_policy>(req.fee_policy));
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet.create_transactions(dsts, req.mixin, req.unlock_time, req.fee, extra, req.subtract_fee);
 
       // reject proposed transactions if there are more than one.  see on_transfer_split below.
       if (ptx_vector.size() != 1)
@@ -222,7 +222,7 @@ namespace tools
 
     try
     {
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet.create_transactions(dsts, req.mixin, req.unlock_time, req.fee, extra, static_cast<tx_fee_policy>(req.fee_policy));
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet.create_transactions(dsts, req.mixin, req.unlock_time, req.fee, extra, req.subtract_fee);
 
       m_wallet.commit_tx(ptx_vector);
 

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -171,7 +171,7 @@ namespace tools
 
     try
     {
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet.create_transactions(dsts, req.mixin, req.unlock_time, req.fee, extra);
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet.create_transactions(dsts, req.mixin, req.unlock_time, req.fee, extra, (tx_fee_policy)req.fee_policy);
 
       // reject proposed transactions if there are more than one.  see on_transfer_split below.
       if (ptx_vector.size() != 1)
@@ -222,7 +222,7 @@ namespace tools
 
     try
     {
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet.create_transactions(dsts, req.mixin, req.unlock_time, req.fee, extra);
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet.create_transactions(dsts, req.mixin, req.unlock_time, req.fee, extra, (tx_fee_policy)req.fee_policy);
 
       m_wallet.commit_tx(ptx_vector);
 

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -97,7 +97,12 @@ namespace wallet_rpc
       uint64_t mixin;
       uint64_t unlock_time;
       std::string payment_id;
-      bool subtract_fee = false;
+      bool subtract_fee;
+
+      request()
+        : subtract_fee(false)
+      {
+      }
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(destinations)
@@ -128,7 +133,12 @@ namespace wallet_rpc
       uint64_t mixin;
       uint64_t unlock_time;
       std::string payment_id;
-      bool subtract_fee = false;
+      bool subtract_fee;
+
+      request()
+        : subtract_fee(false)
+      {
+      }
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(destinations)

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -33,6 +33,7 @@
 #include "cryptonote_core/cryptonote_basic.h"
 #include "crypto/hash.h"
 #include "wallet_rpc_server_error_codes.h"
+#include "wallet2.h"
 namespace tools
 {
 namespace wallet_rpc
@@ -97,7 +98,7 @@ namespace wallet_rpc
       uint64_t mixin;
       uint64_t unlock_time;
       std::string payment_id;
-      uint8_t fee_policy;
+      uint8_t fee_policy = tx_fee_policy::ADD_TO_TOTAL;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(destinations)
@@ -128,7 +129,7 @@ namespace wallet_rpc
       uint64_t mixin;
       uint64_t unlock_time;
       std::string payment_id;
-      uint8_t fee_policy;
+      uint8_t fee_policy = tx_fee_policy::ADD_TO_TOTAL;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(destinations)

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -33,7 +33,6 @@
 #include "cryptonote_core/cryptonote_basic.h"
 #include "crypto/hash.h"
 #include "wallet_rpc_server_error_codes.h"
-#include "wallet2.h"
 namespace tools
 {
 namespace wallet_rpc
@@ -98,7 +97,7 @@ namespace wallet_rpc
       uint64_t mixin;
       uint64_t unlock_time;
       std::string payment_id;
-      uint8_t fee_policy = tx_fee_policy::ADD_TO_TOTAL;
+      bool subtract_fee = false;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(destinations)
@@ -106,7 +105,7 @@ namespace wallet_rpc
         KV_SERIALIZE(mixin)
         KV_SERIALIZE(unlock_time)
         KV_SERIALIZE(payment_id)
-        KV_SERIALIZE(fee_policy)
+        KV_SERIALIZE(subtract_fee)
       END_KV_SERIALIZE_MAP()
     };
 
@@ -129,7 +128,7 @@ namespace wallet_rpc
       uint64_t mixin;
       uint64_t unlock_time;
       std::string payment_id;
-      uint8_t fee_policy = tx_fee_policy::ADD_TO_TOTAL;
+      bool subtract_fee = false;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(destinations)
@@ -137,7 +136,7 @@ namespace wallet_rpc
         KV_SERIALIZE(mixin)
         KV_SERIALIZE(unlock_time)
         KV_SERIALIZE(payment_id)
-        KV_SERIALIZE(fee_policy)
+        KV_SERIALIZE(subtract_fee)
       END_KV_SERIALIZE_MAP()
     };
 

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -97,6 +97,7 @@ namespace wallet_rpc
       uint64_t mixin;
       uint64_t unlock_time;
       std::string payment_id;
+      uint8_t fee_policy;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(destinations)
@@ -104,6 +105,7 @@ namespace wallet_rpc
         KV_SERIALIZE(mixin)
         KV_SERIALIZE(unlock_time)
         KV_SERIALIZE(payment_id)
+        KV_SERIALIZE(fee_policy)
       END_KV_SERIALIZE_MAP()
     };
 
@@ -126,6 +128,7 @@ namespace wallet_rpc
       uint64_t mixin;
       uint64_t unlock_time;
       std::string payment_id;
+      uint8_t fee_policy;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(destinations)
@@ -133,6 +136,7 @@ namespace wallet_rpc
         KV_SERIALIZE(mixin)
         KV_SERIALIZE(unlock_time)
         KV_SERIALIZE(payment_id)
+        KV_SERIALIZE(fee_policy)
       END_KV_SERIALIZE_MAP()
     };
 


### PR DESCRIPTION
A simple boolean option to subtract the transaction fee from first transaction amount.

Would be useful for transferring the whole wallet balance somewhere else, or when you want to guarantee a certain balance after a transaction.  May not be that useful, but I've used this feature in Bitcoin a few times and was annoyed that Litecoin didn't have it.

I'm not 100% sure about the changes to the wallet RPC commands. 
