### PR TITLE
	fix for ArchLinux: avoid fallthru warning in base58.cpp

### DIFF
--- a/src/common/base58.cpp
+++ b/src/common/base58.cpp
@@ -111,13 +111,13 @@ namespace tools
         uint64_t res = 0;
         switch (9 - size)
         {
-        case 1:            res |= *data++;
-        case 2: res <<= 8; res |= *data++;
-        case 3: res <<= 8; res |= *data++;
-        case 4: res <<= 8; res |= *data++;
-        case 5: res <<= 8; res |= *data++;
-        case 6: res <<= 8; res |= *data++;
-        case 7: res <<= 8; res |= *data++;
+        case 1:            res |= *data++; /* FALLTHRU */
+        case 2: res <<= 8; res |= *data++; /* FALLTHRU */
+        case 3: res <<= 8; res |= *data++; /* FALLTHRU */
+        case 4: res <<= 8; res |= *data++; /* FALLTHRU */
+        case 5: res <<= 8; res |= *data++; /* FALLTHRU */
+        case 6: res <<= 8; res |= *data++; /* FALLTHRU */
+        case 7: res <<= 8; res |= *data++; /* FALLTHRU */
         case 8: res <<= 8; res |= *data; break;
         default: assert(false);
         }


### PR DESCRIPTION
This PR is supposed to fix errors reported in [this Reddit post](https://www.reddit.com/r/Aeon/comments/6gvwvj/building_aeon_on_archlinux_need_help/):
(although not tested since I don't have ArchLinux installed on my computer)

```
[ 40%] Building CXX object src/CMakeFiles/common.dir/common/base58.cpp.o
/home/yngve/git/aeon/src/common/base58.cpp: In function ‘uint64_t tools::base58::{anonymous}::uint_8be_to_64(const uint8_t*, size_t)’:
/home/yngve/git/aeon/src/common/base58.cpp:114:32: error: this statement may fall through [-Werror=implicit-fallthrough=]
         case 1:            res |= *data++;
                            ~~~~^~~~~~~~~~
/home/yngve/git/aeon/src/common/base58.cpp:115:9: note: here
         case 2: res <<= 8; res |= *data++;
         ^~~~
/home/yngve/git/aeon/src/common/base58.cpp:115:32: error: this statement may fall through [-Werror=implicit-fallthrough=]
         case 2: res <<= 8; res |= *data++;
                            ~~~~^~~~~~~~~~
/home/yngve/git/aeon/src/common/base58.cpp:116:9: note: here
         case 3: res <<= 8; res |= *data++;
         ^~~~
/home/yngve/git/aeon/src/common/base58.cpp:116:32: error: this statement may fall through [-Werror=implicit-fallthrough=]
         case 3: res <<= 8; res |= *data++;
                            ~~~~^~~~~~~~~~
/home/yngve/git/aeon/src/common/base58.cpp:117:9: note: here
         case 4: res <<= 8; res |= *data++;
         ^~~~
/home/yngve/git/aeon/src/common/base58.cpp:117:32: error: this statement may fall through [-Werror=implicit-fallthrough=]
         case 4: res <<= 8; res |= *data++;
                            ~~~~^~~~~~~~~~
/home/yngve/git/aeon/src/common/base58.cpp:118:9: note: here
         case 5: res <<= 8; res |= *data++;
         ^~~~
/home/yngve/git/aeon/src/common/base58.cpp:118:32: error: this statement may fall through [-Werror=implicit-fallthrough=]
         case 5: res <<= 8; res |= *data++;
                            ~~~~^~~~~~~~~~
/home/yngve/git/aeon/src/common/base58.cpp:119:9: note: here
         case 6: res <<= 8; res |= *data++;
         ^~~~
/home/yngve/git/aeon/src/common/base58.cpp:119:32: error: this statement may fall through [-Werror=implicit-fallthrough=]
         case 6: res <<= 8; res |= *data++;
                            ~~~~^~~~~~~~~~
/home/yngve/git/aeon/src/common/base58.cpp:120:9: note: here
         case 7: res <<= 8; res |= *data++;
         ^~~~
/home/yngve/git/aeon/src/common/base58.cpp:120:32: error: this statement may fall through [-Werror=implicit-fallthrough=]
         case 7: res <<= 8; res |= *data++;
                            ~~~~^~~~~~~~~~
/home/yngve/git/aeon/src/common/base58.cpp:121:9: note: here
         case 8: res <<= 8; res |= *data; break;
```
Or we can instead simply suppress this warning-treated-as-error in CMakeLists.txt.