### PR TITLE
Fix hang in simplewallet when no correct input is given.

### DIFF
--- a/contrib/epee/include/console_handler.h
+++ b/contrib/epee/include/console_handler.h
@@ -263,6 +263,8 @@ namespace epee
         if(!m_stdin_reader.get_line(command))
         {
           LOG_PRINT("Failed to read line.", LOG_LEVEL_0);
+          std::cin.clear();
+          continue;
         }
         string_tools::trim(command);
 


### PR DESCRIPTION
Simplewallet hangs (loop forever with failure) when input is "ended"
(e.g. CTRL-Z or CTRL-D depending on platform). Also, can happen with
pipes/redirects.

	modified:   contrib/epee/include/console_handler.h